### PR TITLE
#168233739 Mentor should be able to reject a mentorship request session

### DIFF
--- a/server/controllers/session_controller.js
+++ b/server/controllers/session_controller.js
@@ -28,6 +28,7 @@ class SessionController {
     }
     return res.status(status.BAD_REQUEST).send({ status: status.BAD_REQUEST, error: `${result.error.details[0].message}` });
   }
+
   mentorViewAllSessionRequests(req, res) {
     const sessionRequests = Session.sessions.filter((session) => session.mentorId === userInfo(res, req.headers.authorisation));
     if (sessionRequests.length < 1) {
@@ -68,7 +69,7 @@ class SessionController {
       });
     }
     const sessionRequest = sessionRequests.filter((el) => el.sessionId == sessionId2);
-  
+
 
     if (sessionRequest.length < 1) { return res.status(404).send({ status: 404, error: 'session not found' }); }
     return res.status(200).send({
@@ -76,13 +77,23 @@ class SessionController {
       data: sessionRequest,
     });
   }
+
   acceptSession = (req, res) => {
     if (isNaN(req.params.id.trim())) {
       return res.status(status.BAD_REQUEST).send({ status: status.BAD_REQUEST, error: 'Session id should be an integer' });
     }
-    
+
     const result = Session.accept(res, req.params.id);
     return res.status(200).send({ status: 200, data: { data: result } });
   }
+
+  // reject session
+ rejectSession = (req, res) => {
+   if (isNaN(req.params.id.trim())) {
+     return res.status(status.BAD_REQUEST).send({ status: status.BAD_REQUEST, error: 'Session id should be an integer' });
+   }
+   const result = Session.reject(res, req.params.id);
+   return res.status(200).send({ status: 200, data: { data: result } });
+ }
 }
 export default SessionController;

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -125,6 +125,7 @@ class UserController {
         err: 'Unable to delete',
       });
     }
+
     getAllMentors(req, res) {
       const allMentors = User.users.filter((user) => user.is_mentor == true);
       if (allMentors.length < 1) {
@@ -137,6 +138,28 @@ class UserController {
       return res.status(200).send({
         status: 200,
         data: allMentors,
+      });
+    }
+
+    GetOneMentor(req, res) {
+      const allMentors = User.users.filter((user) => user.is_mentor == true);
+      if (allMentors.length < 1) {
+        return res.status(404).send({
+          status: 404,
+          message: 'mentors are not available',
+        });
+      }
+
+      const specificMentor = allMentors.find((user) => user.id == req.params.id);
+      if (!specificMentor) {
+        return res.status(404).send({
+          status: 404,
+          error: 'No mentor found',
+        });
+      }
+      return res.status(200).send({
+        status: 200,
+        data: specificMentor,
       });
     }
 }

--- a/server/middleware/protect_routes.js
+++ b/server/middleware/protect_routes.js
@@ -96,7 +96,6 @@ class Authorisation {
       );
     }
   }
-
 }
 
 export default Authorisation;

--- a/server/models/session_model.js
+++ b/server/models/session_model.js
@@ -47,6 +47,7 @@ class Session {
     };
     return newSession;
   };
+
   // accept session
   accept = (res, id) => {
     const session = this.sessions.find((sid) => sid.sessionId === parseInt(id, 10));
@@ -73,7 +74,24 @@ class Session {
     return session;
   }
 
-
-
+  // reject sessions
+  reject = (res, id) => {
+    const session = this.sessions.find((sid) => sid.sessionId === parseInt(id, 10));
+    if (!session) return res.status(404).send({ status: 404, error: 'this session  is not found!' });
+    if (session.status === 'Accept') {
+      return res.status(status.FORBIDDEN).send({
+        status: status.FORBIDDEN,
+        error: 'This session is already accepted',
+      });
+    }
+    if (session.status === 'Reject') {
+      return res.status(status.FORBIDDEN).send({
+        status: status.FORBIDDEN,
+        error: 'This session is already rejected',
+      });
+    }
+    session.status = 'Reject';
+    return session;
+  }
 }
 export default new Session();

--- a/server/routes/session_route.js
+++ b/server/routes/session_route.js
@@ -9,14 +9,20 @@ const router = express.Router();
 
 // creation of object
 const session_controller = new SessionController();
-/ session creation
-router.post('/sessions',authorise.checkUser,session_controller.create);
+
+// session creation
+router.post('/sessions', authorise.checkUser, session_controller.create);
 
 // a mentor can view all mentorship request sessions created against him
-router.get('/sessions', authorise.checkMentor,session_controller.mentorViewAllSessionRequests);
+router.get('/sessions', authorise.checkMentor, session_controller.mentorViewAllSessionRequests);
 
 // a mentor can view a specific mentorship request sessions created against him
-router.get('/sessions/:id', authorise.checkMentor,session_controller.view_specific_session_request);
-// a mentor can accept a mentorship request sessions 
+router.get('/sessions/:id', authorise.checkMentor, session_controller.view_specific_session_request);
+// a mentor can accept a mentorship request sessions
 router.patch('/sessions/:id/accept', session_controller.acceptSession);
-// a mentor can reject a mentorship request sessions 
+// a mentor can reject a mentorship request sessions
+router.patch('/sessions/:id/reject', session_controller.rejectSession);
+
+// a mentee can view all mentorship request sessions created by him
+router.get('/sessions', authorise.checkUser, session_controller.menteeViewAllSessionRequests);
+export default router;

--- a/server/test/test.js
+++ b/server/test/test.js
@@ -291,7 +291,7 @@ describe('request session', () => {
     chai.request(app)
       .post('/api/v1/sessions')
       .send({
- mentorId: 3,
+        mentorId: 3,
         questions: 'ffffffffffffffff',
       })
 
@@ -540,90 +540,90 @@ describe('mentor can view a specific mentorship request session created against 
   });
 });
 describe('mentor can accept mentorship request session ', () => {
-    it('should be able to accept mentorship request session created against him', (done) => {
-      chai.request(app)
-        .patch('/api/v1/sessions/1/accept')
-        .set('authorisation', mentorToken)
-        .set('Accept', 'application/json')
-        .end((err, res) => {
-          expect(res.body).to.be.an('object');
-          expect(res.body).to.have.property('data').to.be.a('object');
-          done();
-        });
-    });
-    it('should not be able to accept mentorship request session which is already accepted', (done) => {
-      chai.request(app)
-        .patch('/api/v1/sessions/1/accept')
-        .set('authorisation', mentorToken)
-        .set('Accept', 'application/json')
-        .end((err, res) => {
-          expect(res.body).to.be.an('object');
-          res.body.should.have.property('status');
-          res.body.should.have.property('error');
-          done();
-        });
-    });
-    it('should not be able to accept mentorship request session which is not does not exist', (done) => {
-      chai.request(app)
-        .patch('/api/v1/sessions/1000/accept')
-        .set('authorisation', mentorToken)
-        .set('Accept', 'application/json')
-        .end((err, res) => {
-          expect(res.body).to.be.an('object');
-          res.body.should.have.property('status');
-          res.body.should.have.property('error');
-          done();
-        });
-    });
+  it('should be able to accept mentorship request session created against him', (done) => {
+    chai.request(app)
+      .patch('/api/v1/sessions/1/accept')
+      .set('authorisation', mentorToken)
+      .set('Accept', 'application/json')
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('data').to.be.a('object');
+        done();
+      });
   });
-  describe('mentor can reject mentorship request session ', () => {
-    it('should be able to reject mentorship request session created against him', (done) => {
-      chai.request(app)
-        .patch('/api/v1/sessions/2/reject')
-        .set('authorisation', mentorToken)
-        .set('Accept', 'application/json')
-        .end((err, res) => {
-          expect(res.body).to.be.an('object');
-          expect(res.body).to.have.property('data').to.be.a('object');
-          res.body.should.have.property('status');
-          done();
-        });
-    });
-    it('should not be able to reject mentorship request session which is already rejected', (done) => {
-      chai.request(app)
-        .patch('/api/v1/sessions/2/reject')
-        .set('authorisation', mentorToken)
-        .set('Accept', 'application/json')
-        .end((err, res) => {
-          expect(res.body).to.be.an('object');
-          res.body.should.have.property('status');
-          res.body.should.have.property('error');
-          done();
-        });
-    });
-    it('should not be able to reject mentorship request session which is already accepted', (done) => {
-      chai.request(app)
-        .patch('/api/v1/sessions/1/reject')
-        .set('authorisation', mentorToken)
-        .set('Accept', 'application/json')
-        .end((err, res) => {
-          expect(res.body).to.be.an('object');
-          res.body.should.have.property('status');
-          res.body.should.have.property('error');
-          done();
-        });
-    });
-    it('should not be able to reject mentorship request session which is not does not exist', (done) => {
-      chai.request(app)
-        .patch('/api/v1/sessions/1000/reject')
-        .set('authorisation', mentorToken)
-        .set('Accept', 'application/json')
-        .end((err, res) => {
-          expect(res.body).to.be.an('object');
-          res.body.should.have.property('status');
-          res.body.should.have.property('error');
-          done();
-        });
-    });
+  it('should not be able to accept mentorship request session which is already accepted', (done) => {
+    chai.request(app)
+      .patch('/api/v1/sessions/1/accept')
+      .set('authorisation', mentorToken)
+      .set('Accept', 'application/json')
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        res.body.should.have.property('status');
+        res.body.should.have.property('error');
+        done();
+      });
   });
-  
+  it('should not be able to accept mentorship request session which is not does not exist', (done) => {
+    chai.request(app)
+      .patch('/api/v1/sessions/1000/accept')
+      .set('authorisation', mentorToken)
+      .set('Accept', 'application/json')
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        res.body.should.have.property('status');
+        res.body.should.have.property('error');
+        done();
+      });
+  });
+});
+describe('mentor can reject mentorship request session ', () => {
+  it('should be able to reject mentorship request session created against him', (done) => {
+    chai.request(app)
+      .patch('/api/v1/sessions/2/reject')
+      .set('authorisation', mentorToken)
+      .set('Accept', 'application/json')
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('data').to.be.a('object');
+        res.body.should.have.property('status');
+        done();
+      });
+  });
+  it('should not be able to reject mentorship request session which is already rejected', (done) => {
+    chai.request(app)
+      .patch('/api/v1/sessions/2/reject')
+      .set('authorisation', mentorToken)
+      .set('Accept', 'application/json')
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        res.body.should.have.property('status');
+        res.body.should.have.property('error');
+        done();
+      });
+  });
+  it('should not be able to reject mentorship request session which is already accepted', (done) => {
+    chai.request(app)
+      .patch('/api/v1/sessions/1/reject')
+      .set('authorisation', mentorToken)
+      .set('Accept', 'application/json')
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        res.body.should.have.property('status');
+        res.body.should.have.property('error');
+        done();
+      });
+  });
+  it('should not be able to reject mentorship request session which is not does not exist', (done) => {
+    chai.request(app)
+      .patch('/api/v1/sessions/1000/reject')
+      .set('authorisation', mentorToken)
+      .set('Accept', 'application/json')
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        res.body.should.have.property('status');
+        res.body.should.have.property('error');
+        done();
+      });
+  });
+});
+


### PR DESCRIPTION
#### What does this PR do?
-  Add reject mentorship session request endpoint
#### Description of Task to be completed?

- add an endpoint to reject a mentorship session request
- write unit tests for the endpoint

#### How should this be manually tested?
Clone this repo
cd into the main directory
install the required dependencies
Set the required environment variables
git checkout ft-reject-request-168233739
Run npm run dev_start
Test the api/v1/sessions/id/reject endpoint in postman 
#### What are the relevant pivotal tracker stories?
#168233691